### PR TITLE
docs: address auth_strength formula clarity

### DIFF
--- a/docs/specification/spec.md
+++ b/docs/specification/spec.md
@@ -734,6 +734,7 @@ auth_strength = sum(strength_scores) / schemes_count
 
 
 Where:
+
 - `strength_scores` is the list of calculated scheme strengths
 - `schemes_count` is the number of defined schemes
 


### PR DESCRIPTION
Updated the formula for calculating auth_strength to use clearer variable names and standard divide (safe divide is assumed always in every formula)